### PR TITLE
Minor touch ups

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,8 +8,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
     - name: Build deps
       run: |
         make deps

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,19 +1,18 @@
-name: CCPP CI
+name: C/C++ CI
 
 on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
-    - name: prepare
+    - name: Build deps
       run: |
         make deps
-    - name: build
+    - name: Build
       run: |
-        make -j
+        make -j2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM ubuntu:18.04 as gcc-builder
 
-LABEL maintainer.0="Aditya Kresna (kresna@bitwyre.com)"
-
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y build-essential automake autoconf autotools-dev make libtool zlib1g-dev && \
@@ -11,11 +9,14 @@ RUN apt-get update && \
 
 COPY . /app/megaphone
 WORKDIR /app
-RUN make deps -C megaphone && make -C megaphone
+RUN make deps -C megaphone && \
+    make -C megaphone
 
 # Stage 2 - Production Image
 
 FROM ubuntu:18.04
+
+LABEL maintainer="Aditya Kresna (kresna@bitwyre.com), Yefta Sutanto (yefta@bitwyre.com)"
 
 COPY --from=gcc-builder /app/megaphone/megaphone /usr/bin/
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,14 @@
   </a>
 </p>
 
-![Workflow Status](https://github.com/bitwyre/megaphone/workflows/CCPP%20CI/badge.svg)
+![Workflow Status](https://github.com/bitwyre/megaphone/workflows/C%2FC%2B%2B%20CI/badge.svg)
 
 # Megaphone distributes events to many web browsers
 
-## Authors
-
-- [Alex Hultman](https://github.com/alexhultman)
-
 ## Description
 
-This project is essentially a Redis-to-WebSocket adapter in the sense that it will publish to WebSocket clients, whatever <string> you publish to Redis.
-  
+This project is essentially a Redis-to-WebSocket adapter in the sense that it will publish to WebSocket clients, whatever *string* you publish to Redis.
+
 If you connect to redis via `redis-cli` and type `publish trades "some json here"`, this project will send over WebSocket to all connected clients the message "some json here".
 
 This means we could reuse this project for `trades`, `ticker` and `orderbook` without any code change, only a few runtime environment variables changed such as what topic we subscribe to in Redis.
@@ -30,14 +26,14 @@ Now you should have an executable, megaphone, without any non-standard dependenc
 
 ## Usage
 
-Megaphone is a stand-alone executable you launch with a few envionrment variables:
+Megaphone is a stand-alone executable you launch with a few environment variables:
 
-* REDIS_HOST is the address, hostname to the main, internal, Redis pub/sub node
-* REDIS_PORT is the port to said Redis node
-* REDIS_TOPIC is the topic we subscribe to, and listen to events on. What you publish to Redis on this topic will be sent to all WebSockets connected to this Megaphone instance
-* SERVICE_IP is the hostname of the WebSocket server
-* SERVICE_PORT is the port of the WebSocket server
-* SERVICE_PATH is the path of the WebSocket server
+* `REDIS_HOST` is the address/hostname to the main, internal, Redis pub/sub node
+* `REDIS_PORT` is the port to said Redis node
+* `REDIS_TOPIC` is the topic we subscribe to, and listen to events on. What you publish to Redis on this topic will be sent to all WebSocket clients connected to this Megaphone instance
+* `SERVICE_IP` is the hostname of the WebSocket server
+* `SERVICE_PORT` is the port of the WebSocket server
+* `SERVICE_PATH` is the path of the WebSocket server
 
 Example:
 
@@ -62,11 +58,14 @@ docker run --rm \
     bitwyre/megaphone:latest
 ```
 
-## Contributors
+## Author
 
 - [Alex Hultman](https://github.com/alexhultman)
-- [Dendi](https://github.com/dendisuhubdy)
-- [Kresna](https://github.com/ujang360)
+
+## Contributors
+
+- [Dendi Suhubdy](https://github.com/dendisuhubdy)
+- [Aditya Kresna](https://github.com/ujang360)
 
 # Copyright
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ docker run --rm \
 
 - [Dendi Suhubdy](https://github.com/dendisuhubdy)
 - [Aditya Kresna](https://github.com/ujang360)
+- [Yefta Sutanto](https://github.com/nevrending)
 
 # Copyright
 


### PR DESCRIPTION
GH Actions:
- Changed `-j` to `-j2` since Action runners have 2 CPU cores
- Use actions/checkout@v2
- Use `ubuntu-18.04`

Dockerfile:
- Move maintainer label to the release image

README:
- Minor touch ups