### PR TITLE
Fix client topic subscribe mismatch on REDIS_TOPIC set

### DIFF
--- a/megaphone.cpp
+++ b/megaphone.cpp
@@ -144,11 +144,8 @@ int main() {
         /* 100kb then you're cut from the team */
         .maxBackpressure = 100 * 1024,
         /* Handlers */
-        .open = [](auto *ws, auto *req) {
-            /* What we subscribe to internally makes no difference (yet?) */
-
-            /* Todo: we could support a set of redis topics? */
-            ws->subscribe("trades");
+        .open = [redisTopic](auto *ws, auto *req) {
+            ws->subscribe(redisTopic);
         }
     }).listen(hostname, port, [port, hostname](auto *listenSocket) {
         if (listenSocket) {


### PR DESCRIPTION
@alexhultman-2fa I tested the `megaphone` docker with `REDIS_TOPIC` !=  `"trades"` and apparently the `megaphone` didn't forward the `Redis PubSub Message` to its client(s). So I decided to automatically register new clients into the exact same topic as `Redis PubSub Topic`.  If you have a better suggestion, please don't hesitate to deny this PR, or suggest change :pray:

@dendisuhubdy & @nevrending, apparently we need to change the Websocket Public API endpoint to something like `/ws/public/ticker/btc_usd` rather than `/ws/public/ticker?asset_name=btc_usd` to minimize the service owned state/easier scalability, which means 1 `megaphone` for each endpoint class (ie. [ws ticker endpoint](https://api.bitwyre.com/#ws-ticker)) + `REDIS_TOPIC`

@sdmg15 thanks for your [blog](https://sdmg15.com/blog/2019/11/24/cpp-lambda-basics/#lambda-captures-list) :grin:

Please review guys.